### PR TITLE
BT-1400 updated migrator to allow discount (promo) codes via API

### DIFF
--- a/migrator.py
+++ b/migrator.py
@@ -108,6 +108,7 @@ with open (response_filename,"w", newline="") as f:
 #      "battery-backup-legals-shown": battery_backup_legals_shown,
       "landline-number": landline_number,
       "service-product-code": row["service_product_code"],
+      "promo-code": row["promo_code"],
       "hardware-product-code": hardware_product_code,
       "max-speed": row["max_speed"],
       "payment-token": payment_token,

--- a/test_discount.csv
+++ b/test_discount.csv
@@ -1,0 +1,2 @@
+provider_reference_number,previous_provider,wholesale_supplier,first_name,last_name,email,date_of_birth,contact_number,technology_type,max_speed,service_product_code,promo_code,last_billing_date,location_id,sub_premises,street_number,street_name,street_type,city,state,postcode,radius_username,radius_password
+201806191235-01,Active Utilities,LBNCO,Test Discount,Test Little Piggy,201806191235@mailinator.com,1990-07-13,0416930734,FTTH,100,12/1-UNL60,DSCT-15OFF6MBASIC60,2018-05-07,1,,22,Elderiana,Link,Banskia Grove,WA,6031,20180613defg,pass123


### PR DESCRIPTION
Fixed the migrator to accept orders via API with a discount attached.

See example: http://abb-sp-dev.amaysim.net/profiles/opportunity/21797-Amaysim-Broadband-Order